### PR TITLE
EventConfiguration annotation based configuration, maven deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# CDI style event handling for Spring
+
+## Configuration
+
+### Programmatic
+
+Programmatic configuration can be done by importing the ```com.github.spring.event.config.EventConfiguration```
+
+```java
+@ComponentScan
+@EnableAutoConfiguration
+@Configuration
+@Import({com.github.spring.event.config.EventConfiguration.class})
+public class MyConfig {...{
+```
+
+### XML
+
+Configuring in XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:event="http://spring-event-annotations.github.com"
+	xsi:schemaLocation="http://spring-event-annotations.github.com http://spring-event-annotations.github.com/spring-event-1.0.xsd
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	<context:annotation-config />
+    <context:component-scan base-package="com.github.spring.event.samples.basic" />
+    <bean id="executor" class="org.springframework.core.task.SyncTaskExecutor" />
+    <!-- 
+         Executor attribute is optional and it specifies the java.util.Executor 
+         instance to use when invoking asynchronous methods. If not provided, 
+         an instance of org.springframework.core.task.SimpleAsyncTaskExecutor 
+         will be used by default. 
+    -->
+    <event:annotation-driven executor="executor"/>
+</beans>
+```
+
+## Firing events
+
+Event class must be created
+
+    public class OnConnectedEvent {
+    
+       private boolean connected;
+    
+       public OnConnectedEvent(boolean c) {
+          connected = c;
+       }
+    
+       public boolean isConnected() {
+          return connected;
+       }
+    
+       public void setConnected(boolean connected) {
+          this.connected = connected;
+       }
+    
+       @Override
+       public boolean equals(Object o) {
+          if (this == o) return true;
+          if (!(o instanceof OnConnectedEvent)) return false;
+          OnConnectedEvent that = (OnConnectedEvent) o;
+          return Objects.equal(connected, that.connected);
+       }
+    
+       @Override
+       public int hashCode() {
+          return Objects.hashCode(connected);
+       }
+    }
+
+Events must be injected and then fired
+
+    @Autowired
+    private Event<OnConnectedEvent> connectionEvent;
+
+    private void fireEvent(boolean connected) {
+        connectionEvent.fire(new OnConnectedEvent(connected));
+    }
+
+## Observing events
+
+Methods annotated with *@Observes* will respond to events.
+
+    public void onConnectionChanged(@Observes OnConnectedEvent evt) {
+        if(evt.isConnected()) {
+         //TODO   
+        } else {
+         //TODO
+        }
+    }

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.kedzie.spring-event-annotations</groupId>
     <artifactId>spring-event-annotations</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>spring-event-annotations</name>
@@ -15,7 +15,7 @@
         <url>http://github.com/kedzie/spring-event-annotations</url>
         <connection>scm:git:https://github.com/kedzie/spring-event-annotations.git</connection>
         <developerConnection>scm:git:https://github.com/kedzie/spring-event-annotations.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>1.0.1</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.kedzie.spring-event-annotations</groupId>
     <artifactId>spring-event-annotations</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
 
     <name>spring-event-annotations</name>
@@ -15,7 +15,7 @@
         <url>http://github.com/kedzie/spring-event-annotations</url>
         <connection>scm:git:https://github.com/kedzie/spring-event-annotations.git</connection>
         <developerConnection>scm:git:https://github.com/kedzie/spring-event-annotations.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>1.0.0</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.kedzie.spring-event-annotations</groupId>
     <artifactId>spring-event-annotations</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>spring-event-annotations</name>
@@ -15,7 +15,7 @@
         <url>http://github.com/kedzie/spring-event-annotations</url>
         <connection>scm:git:https://github.com/kedzie/spring-event-annotations.git</connection>
         <developerConnection>scm:git:https://github.com/kedzie/spring-event-annotations.git</developerConnection>
-        <tag>1.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,61 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.spring-event-annotations</groupId>
+    <groupId>com.github.kedzie.spring-event-annotations</groupId>
     <artifactId>spring-event-annotations</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>spring-event-annotations</name>
-    <url>http://spring-event-annotations.github.com</url>
+    <url>http://github.com/kedzie/spring-event-annotations</url>
+
+    <description>CDI style event handling for Spring Framework</description>
+
+    <scm>
+        <url>http://github.com/kedzie/spring-event-annotations</url>
+        <connection>scm:git:https://github.com/kedzie/spring-event-annotations.git</connection>
+        <developerConnection>scm:git:https://github.com/kedzie/spring-event-annotations.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>Apache</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <email>mark.kedzierski@gmail.com</email>
+            <name>Marek Kedzierski</name>
+            <url>http://kedzie.github.com</url>
+            <roles>
+                <role>Repository Releaser</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/kedzie/spring-event-annotations/issues</url>
+    </issueManagement>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <name>Nexus Release Repository</name>
+            <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <java-version>1.6</java-version>
-        <org.springframework-version>3.1.0.RELEASE</org.springframework-version>
+        <org.springframework-version>4.1.6.RELEASE</org.springframework-version>
         <org.aspectj-version>1.6.9</org.aspectj-version>
-        <org.slf4j-version>1.5.10</org.slf4j-version>
+        <org.slf4j-version>1.7.7</org.slf4j-version>
     </properties>
+
     <dependencies>
         <!-- Spring -->
         <dependency>
@@ -24,13 +64,18 @@
             <version>${org.springframework-version}</version>
             <scope>provided</scope>            
         </dependency>
-        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${org.springframework-version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${org.slf4j-version}</version>
-            <scope>test</scope>
         </dependency>
+        <!-- Test -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -63,12 +108,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${org.springframework-version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>${org.springframework-version}</version>
             <scope>test</scope>
@@ -76,13 +115,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.7</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.8.5</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
 
@@ -104,11 +143,80 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
                 <configuration>
                     <source>${java-version}</source>
                     <target>${java-version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.2</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.kedzie.spring-event-annotations</groupId>
     <artifactId>spring-event-annotations</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>spring-event-annotations</name>
@@ -15,7 +15,7 @@
         <url>http://github.com/kedzie/spring-event-annotations</url>
         <connection>scm:git:https://github.com/kedzie/spring-event-annotations.git</connection>
         <developerConnection>scm:git:https://github.com/kedzie/spring-event-annotations.git</developerConnection>
-        <tag>1.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/src/main/java/com/github/spring/event/annotation/ObservesAnotationBeanPostProcessor.java
+++ b/src/main/java/com/github/spring/event/annotation/ObservesAnotationBeanPostProcessor.java
@@ -40,7 +40,7 @@ public class ObservesAnotationBeanPostProcessor implements BeanPostProcessor {
 				}
 				Annotation[] annotations = field.getAnnotations();
 				for(Annotation ann : annotations) {
-					if(ann.annotationType().isAnnotationPresent(Qualifier.class)) {					
+					if(ann.annotationType().isAnnotationPresent(Qualifier.class)) {
 						
 						LOG.info("found qualified Event \"@{}\" of bean \"{}\"",
 								new Object[] { ann.annotationType().getSimpleName(), bean.getClass().getName() });

--- a/src/main/java/com/github/spring/event/annotation/Qualifier.java
+++ b/src/main/java/com/github/spring/event/annotation/Qualifier.java
@@ -5,5 +5,6 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
 public @interface Qualifier {
-	String value() default "";
+   String value() default "";
 }
+

--- a/src/main/java/com/github/spring/event/config/AnnotationDrivenEventBeanDefinitionParser.java
+++ b/src/main/java/com/github/spring/event/config/AnnotationDrivenEventBeanDefinitionParser.java
@@ -19,6 +19,7 @@ import com.github.spring.event.annotation.ObservesAnotationBeanPostProcessor;
 public class AnnotationDrivenEventBeanDefinitionParser implements BeanDefinitionParser {
 
 	static final String EVENT_REGISTRY_BEAN_NAME = "com.github.spring.event.config.internalEventRegistry";
+	static final String EXECUTOR_BEAN_NAME = "com.github.spring.event.config.internalExecutor";
 	static final String ANNOTATION_POST_PROCESSOR_BEAN_NAME = "com.github.spring.event.config.internalAnnotationBeanPostProcessor";
 	
 	public BeanDefinition parse(Element element, ParserContext parserContext) {

--- a/src/main/java/com/github/spring/event/config/AnnotationDrivenEventBeanDefinitionParser.java
+++ b/src/main/java/com/github/spring/event/config/AnnotationDrivenEventBeanDefinitionParser.java
@@ -1,8 +1,10 @@
 package com.github.spring.event.config;
 
 import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.support.AutowireCandidateQualifier;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
@@ -16,8 +18,8 @@ import com.github.spring.event.annotation.ObservesAnotationBeanPostProcessor;
 
 public class AnnotationDrivenEventBeanDefinitionParser implements BeanDefinitionParser {
 
-	static final String EVENT_REGISTRY_BEAN_NAME = AnnotationDrivenEventBeanDefinitionParser.class.getPackage().getName() + ".internalEventRegistry";
-	static final String ANNOTATION_POST_PROCESSOR_BEAN_NAME = AnnotationDrivenEventBeanDefinitionParser.class.getPackage().getName() + ".internalAnnotationBeanPostProcessor";
+	static final String EVENT_REGISTRY_BEAN_NAME = "com.github.spring.event.config.internalEventRegistry";
+	static final String ANNOTATION_POST_PROCESSOR_BEAN_NAME = "com.github.spring.event.config.internalAnnotationBeanPostProcessor";
 	
 	public BeanDefinition parse(Element element, ParserContext parserContext) {
 		
@@ -33,6 +35,7 @@ public class AnnotationDrivenEventBeanDefinitionParser implements BeanDefinition
 		final RootBeanDefinition eventRegistry = new RootBeanDefinition(EventRegistry.class);
 		eventRegistry.setSource(elementSource);
         eventRegistry.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+		eventRegistry.addQualifier(new AutowireCandidateQualifier(Qualifier.class));
         
         String executor = element.getAttribute("executor");
 		if (StringUtils.hasText(executor)) {

--- a/src/main/java/com/github/spring/event/config/EventConfiguration.java
+++ b/src/main/java/com/github/spring/event/config/EventConfiguration.java
@@ -18,6 +18,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 
+import java.util.concurrent.Executor;
+
 /**
  * Configures @Observes events
  * @author kedzie
@@ -25,11 +27,17 @@ import org.springframework.core.task.SimpleAsyncTaskExecutor;
 @Configuration
 public class EventConfiguration {
 
+   @Bean(name = AnnotationDrivenEventBeanDefinitionParser.EXECUTOR_BEAN_NAME)
+   @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+   public Executor executor() {
+      return new SimpleAsyncTaskExecutor();
+   }
+
    @Bean(name = AnnotationDrivenEventBeanDefinitionParser.EVENT_REGISTRY_BEAN_NAME)
    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-   public EventRegistry eventRegistry() {
+   public EventRegistry eventRegistry(Executor executor) {
       EventRegistry registry = new EventRegistry();
-      registry.setExecutor(new SimpleAsyncTaskExecutor());
+      registry.setExecutor(executor);
       return registry;
    }
 

--- a/src/main/java/com/github/spring/event/config/EventConfiguration.java
+++ b/src/main/java/com/github/spring/event/config/EventConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 CNH Industrial NV. All rights reserved.
+ *
+ * This software contains proprietary information of CNH Industrial NV. Neither
+ * receipt nor possession thereof confers any right to reproduce, use, or
+ * disclose in whole or in part any such information without written
+ * authorization from CNH Industrial NV.
+ */
+
+package com.github.spring.event.config;
+
+import com.github.spring.event.EventRegistry;
+import com.github.spring.event.annotation.ObservesAnotationBeanPostProcessor;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Role;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+
+/**
+ * Configures @Observes events
+ * @author kedzie
+ */
+@Configuration
+public class EventConfiguration {
+
+   @Bean(name = AnnotationDrivenEventBeanDefinitionParser.EVENT_REGISTRY_BEAN_NAME)
+   @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+   public EventRegistry eventRegistry() {
+      EventRegistry registry = new EventRegistry();
+      registry.setExecutor(new SimpleAsyncTaskExecutor());
+      return registry;
+   }
+
+   @Bean(name = AnnotationDrivenEventBeanDefinitionParser.ANNOTATION_POST_PROCESSOR_BEAN_NAME)
+   @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+   public ObservesAnotationBeanPostProcessor eventAnnotationProcessor(EventRegistry r) {
+      ObservesAnotationBeanPostProcessor processor = new ObservesAnotationBeanPostProcessor();
+      processor.setEventRegistry(r);
+      return processor;
+   }
+}

--- a/src/test/java/com/github/spring/event/samples/basic/LoginListenerAnnotationTest.java
+++ b/src/test/java/com/github/spring/event/samples/basic/LoginListenerAnnotationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 CNH Industrial NV. All rights reserved.
+ *
+ * This software contains proprietary information of CNH Industrial NV. Neither
+ * receipt nor possession thereof confers any right to reproduce, use, or
+ * disclose in whole or in part any such information without written
+ * authorization from CNH Industrial NV.
+ */
+
+package com.github.spring.event.samples.basic;
+
+import com.github.spring.event.Event;
+import com.github.spring.event.EventHandledCallback;
+import com.github.spring.event.annotation.Observes;
+import com.github.spring.event.annotation.ObservesAnotationBeanPostProcessor;
+import com.github.spring.event.config.EventConfiguration;
+import com.github.spring.event.samples.qualifiers.Item;
+import com.github.spring.event.samples.qualifiers.ItemEventListener;
+import com.github.spring.event.samples.qualifiers.ItemModified;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.concurrent.Executor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes={ EventConfiguration.class, LoginListenerAnnotationTest.TestConfig.class })
+public class LoginListenerAnnotationTest {
+
+	@Configuration
+	@ComponentScan(value = {"com.github.spring.event.samples.basic"})
+	public static class TestConfig {
+
+		@Bean
+		@Primary
+		public Executor getExecutor() {
+			return new SyncTaskExecutor();
+		}
+	}
+
+	@Autowired
+	private ApplicationContext context;
+	
+	@Autowired
+	private Event<LoggedInEvent> loggedInEvent;
+	
+	@Autowired
+	private Event<LoggedOutEvent> loggedOutEvent;
+	
+	private EventHandledCallback eventHandledCallback = mock(EventHandledCallback.class);
+	
+	@Before
+	public void verifyContext() {
+		Assert.assertNotNull(context.getBean(ObservesAnotationBeanPostProcessor.class));
+	}
+	
+	@Test
+	public void receivedLoggedInEvent() throws InterruptedException {
+		loggedInEvent.fire(new LoggedInEvent(eventHandledCallback));
+		verify(eventHandledCallback).eventHandled("userLoggedIn");
+	}
+	
+	@Test
+	public void receivedLoggedOutEvent() throws InterruptedException {
+		loggedOutEvent.fire(new LoggedOutEvent(eventHandledCallback));
+		verify(eventHandledCallback).eventHandled("userLoggedOut");		
+	}
+}

--- a/src/test/java/com/github/spring/event/samples/qualifiers/ItemCreated.java
+++ b/src/test/java/com/github/spring/event/samples/qualifiers/ItemCreated.java
@@ -1,8 +1,13 @@
 package com.github.spring.event.samples.qualifiers;
 
-import java.lang.annotation.*;
 
 import com.github.spring.event.annotation.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/com/github/spring/event/samples/qualifiers/ItemListenerWithQualifiersAnnotationTest.java
+++ b/src/test/java/com/github/spring/event/samples/qualifiers/ItemListenerWithQualifiersAnnotationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 CNH Industrial NV. All rights reserved.
+ *
+ * This software contains proprietary information of CNH Industrial NV. Neither
+ * receipt nor possession thereof confers any right to reproduce, use, or
+ * disclose in whole or in part any such information without written
+ * authorization from CNH Industrial NV.
+ */
+
+package com.github.spring.event.samples.qualifiers;
+
+import com.github.spring.event.Event;
+import com.github.spring.event.EventHandledCallback;
+import com.github.spring.event.annotation.ObservesAnotationBeanPostProcessor;
+import com.github.spring.event.config.EventConfiguration;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.concurrent.Executor;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { EventConfiguration.class, ItemListenerWithQualifiersAnnotationTest.TestConfig.class })
+public class ItemListenerWithQualifiersAnnotationTest {
+
+	@Configuration
+	@ComponentScan(value = {"com.github.spring.event.samples.qualifiers"})
+	public static class TestConfig {
+
+		@Bean
+		@Primary
+		public Executor getExecutor() {
+			return new SyncTaskExecutor();
+		}
+	}
+
+	@Autowired
+	private ApplicationContext context;
+	
+	@Autowired
+	@ItemCreated
+	private Event<Item> itemCreatedEvent;
+	
+	@Autowired
+	@ItemModified(someParam = "value")
+	private Event<Item> itemModifiedEvent;
+	
+	private EventHandledCallback eventHandledCallback = mock(EventHandledCallback.class);
+	
+	@Before
+	public void verifyContext() {
+		Assert.assertNotNull(context.getBean(ObservesAnotationBeanPostProcessor.class));
+	}
+	
+	@Test
+	public void itemCreated() throws InterruptedException {
+		itemCreatedEvent.fire(new Item(eventHandledCallback));
+		verify(eventHandledCallback).eventHandled("itemCreated");
+	}
+	
+	@Test
+	public void itemModified() throws InterruptedException {
+		itemModifiedEvent.fire(new Item(eventHandledCallback));
+		verify(eventHandledCallback).eventHandled("itemModified");
+	}
+}

--- a/src/test/java/com/github/spring/event/samples/qualifiers/ItemModified.java
+++ b/src/test/java/com/github/spring/event/samples/qualifiers/ItemModified.java
@@ -1,8 +1,10 @@
 package com.github.spring.event.samples.qualifiers;
 
-import java.lang.annotation.*;
 
 import com.github.spring.event.annotation.Qualifier;
+
+import java.lang.annotation.*;
+
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
- Annotation configuration using the **EventConfiguration** class
- Use Spring built-in [Qualifier](http://docs.spring.io/autorepo/docs/spring/4.0.6.RELEASE/javadoc-api/org/springframework/beans/factory/annotation/Qualifier.html) class instead of homegrown one
- Updated **pom.xml** for Sonatype deployment _(to maven central)_
